### PR TITLE
absorbメタデータが指定された変数が自動的にabsorbされることを確認するテスト

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 .idea
 *.hxproj
 /out
+
+## MUnit
+/report
+test/TestMain.hx
+test/TestSuite.hx

--- a/.munit
+++ b/.munit
@@ -1,0 +1,6 @@
+version=2.1.0
+src=test
+bin=out
+report=report
+hxml=test.hxml
+classPaths=src

--- a/test.hxml
+++ b/test.hxml
@@ -1,0 +1,57 @@
+## Flash 9+
+-main TestMain
+-lib munit
+-lib hamcrest
+-cp src
+
+-cp test
+-swf-version 11
+-swf out/as3_test.swf
+
+--next
+
+## Flash 8
+-main TestMain
+-lib munit
+-lib hamcrest
+-cp src
+
+-cp test
+-swf-version 8
+-swf out/as2_test.swf
+
+--next
+
+## JavaScript
+-main TestMain
+-lib munit
+-lib hamcrest
+-cp src
+
+-cp test
+-js out/js_test.js
+
+--next
+
+## Neko
+-main TestMain
+-lib munit
+-lib hamcrest
+-cp src
+
+-cp test
+-neko out/neko_test.n
+
+--next
+
+## CPP
+-main TestMain
+-lib munit
+-lib hamcrest
+-cp src
+
+-cp test
+#-D HXCPP_M64
+-cpp out/cpp_test
+
+

--- a/test/AutoAbsorbTest.hx
+++ b/test/AutoAbsorbTest.hx
@@ -10,7 +10,7 @@ class AutoAbsorbTest
 {
 	public function new() { }
 	
-	@Test("ChildGearで@:absorbを指定したSomethingは自動的にabsorbされる")
+	@Test("Childで@:absorbを指定したSomethingはdiffusibleのタイミングで自動的にabsorbされている")
 	private function childGearAbsorbSomething():Void 
 	{
 		var parent = new Parent();
@@ -18,14 +18,18 @@ class AutoAbsorbTest
 		
 		parent.gear.diffusibleHandlerList.add(function (tool:GearDiffuseTool):Void
 		{
-			parent.something = new Something("John Doe");
-			tool.diffuse(parent.something, Something);
+			// parentでSomethingを拡散
+			tool.diffuse(new Something("John Doe"), Something);
+			// parentの子にChildを登録
 			tool.bookChild(child);
 		});
 		
 		child.gear.diffusibleHandlerList.add(function (tool:GearDiffuseTool):Void 
 		{
+			// @:absorbを指定したSomethingは、diffusible内で使用することができる
+			// （これ以前に自動的にabsorbが行われている）
 			Assert.isNotNull(child.something);
+			// 名前はparentで拡散したものと一致する
 			Assert.areEqual(child.something.name, "John Doe");
 		});
 		
@@ -47,7 +51,6 @@ private class Something {
 /* ParentGear */
 private class Parent extends GearHolderImpl 
 {
-	public var something:Something;
 	public function new() { super(); }
 }
 

--- a/test/AutoAbsorbTest.hx
+++ b/test/AutoAbsorbTest.hx
@@ -1,0 +1,69 @@
+package ;
+
+import jp.sipo.gipo.core.Gear.GearDispatcherKind;
+import jp.sipo.gipo.core.GearDiffuseTool;
+import jp.sipo.gipo.core.GearHolderImpl;
+
+import massive.munit.Assert;
+
+class AutoAbsorbTest
+{
+	public function new() { }
+	
+	@Test("ChildGearで@:absorbを指定したSomethingは自動的にabsorbされる")
+	private function childGearAbsorbSomething():Void 
+	{
+		var top:Top = new Top();
+		top.gearOutside().initializeTop(null);
+		
+		var child:Child = top.child;
+		
+		Assert.isNotNull(child.something);
+		Assert.areEqual(child.something.name, "John Doe");
+	}
+	
+}
+
+// //////////////////////////////////////////////////////////////////
+
+/* Diffused Something */
+private class Something {
+	public var name:String;
+	public function new(name:String) {
+		this.name = name;
+	}
+}
+
+/* TopGear */
+private class Top extends GearHolderImpl 
+{
+	public var something:Something;
+	public var child:Child;
+	
+	public function new() { super(); }
+	
+	@:handler(GearDispatcherKind.Diffusible)
+	private function diffusible(tool:GearDiffuseTool):Void 
+	{
+		this.something = new Something("John Doe");
+		tool.diffuse(something, Something);
+		
+		this.child = new Child();
+		tool.bookChild(child);
+	}
+}
+
+/* ChildGear */
+private class Child extends GearHolderImpl 
+{
+	@:absorb
+	public var something:Something;
+	
+	public function new() { super(); }
+	
+	@:handler(GearDispatcherKind.Run)
+	private function run():Void 
+	{
+		
+	}
+}

--- a/test/AutoAbsorbTest.hx
+++ b/test/AutoAbsorbTest.hx
@@ -23,7 +23,7 @@ class AutoAbsorbTest
 			tool.bookChild(child);
 		});
 		
-		child.gear.runHandlerList.add(function ():Void 
+		child.gear.diffusibleHandlerList.add(function (tool:GearDiffuseTool):Void 
 		{
 			Assert.isNotNull(child.something);
 			Assert.areEqual(child.something.name, "John Doe");


### PR DESCRIPTION
Jenkinsなどでテストを走らせることは、
一先ずないとして`TestMain.hx`、`TestSuite.hx`は管理から外した
