### PR TITLE
同一フレーム内の処理をトリガーとして送信されるReadyによって、再現が途中で止まる現象を修正

### DIFF
--- a/gipo/src/jp/sipo/gipo/reproduce/Reproduce.hx
+++ b/gipo/src/jp/sipo/gipo/reproduce/Reproduce.hx
@@ -126,7 +126,6 @@ class Reproduce<TUpdateKind> extends StateSwitcherGearHolderLowLevelImpl
 	 */
 	public function checkCanProgress():Bool
 	{
-		canProgress = replayer.checkCanProgress();
 		return canProgress;
 	}
 	
@@ -147,6 +146,9 @@ class Reproduce<TUpdateKind> extends StateSwitcherGearHolderLowLevelImpl
 	 */
 	public function startOutFramePhase():Void
 	{
+		// 進行可能かの切り替えは、そのフレーム間フェーズの開始時に反映する。
+		canProgress = replayer.checkCanProgress();
+
 		startPhase(ReproducePhase.OutFrame);
 	}
 	/**

--- a/gipo/src/jp/sipo/gipo/reproduce/ReproduceReplay.hx
+++ b/gipo/src/jp/sipo/gipo/reproduce/ReproduceReplay.hx
@@ -141,13 +141,15 @@ class ReproduceReplay<TUpdateKind> extends StateGearHolderImpl implements Reprod
 	 */
 	public function endPhase(phaseValue:ReproducePhase<TUpdateKind>, canProgress:Bool):Void
 	{
-		if (!canProgress) return;
 		// 再生予定リストを再生
 		while (nextLogPartList.length != 0)
 		{
 			var part:LogPart<TUpdateKind> = nextLogPartList[0];
 			// phaseが一致しているもののでなければ終了
 			if (!part.equalPhase(phaseValue)) break;
+			// 実際のイベント待ちの処理だったら終了
+			if (yetReadyList.length > 0 && yetReadyList[0] == part) break;
+			
 			// 削除
 			nextLogPartList.shift();
 			// 実行

--- a/template/src/jp/sipo/gipo_framework_example/scene/mock2/Mock2PilotView.hx
+++ b/template/src/jp/sipo/gipo_framework_example/scene/mock2/Mock2PilotView.hx
@@ -37,7 +37,7 @@ class Mock2PilotView extends PilotViewScene implements Mock2ViewOrder
 		uiContainer = gear.addChild(new MinimalcompsGipoContainer(uiLayer));
 		// 表示設置
 		// ラベルの設置
-		uiContainer.addLabel("開発テスト画面2");
+		uiContainer.addLabel("開発テスト画面2 準備完了");
 		// ボタンの設置
 		uiContainer.addPushButton("遷移テスト", demoChangeSceneButton_click);
 		

--- a/template/src/jp/sipo/gipo_framework_example/scene/mock2/Mock2ReadyPilotView.hx
+++ b/template/src/jp/sipo/gipo_framework_example/scene/mock2/Mock2ReadyPilotView.hx
@@ -58,7 +58,8 @@ class Mock2ReadyPilotView extends PilotViewScene implements Mock2ReadyViewOrder
 		asyncLabel = uiContainer.addLabel("asyncLabel");
 		
 		// 仮想的なViewの準備をするために、ランダムで待ちフレームを決める
-		asyncCountMax = 30 + Math.floor(Math.random() * 30 * 5);
+		var candidates = [1, 2, 150, 151];
+		asyncCountMax = candidates[Std.random(candidates.length)];
 		
 		drawSyncLabel();
 		drawAsyncLabel();


### PR DESCRIPTION
- Readyの待ち合わせによって、Readyのトリガーとなっている処理まで止められてしまう現象を修正
- Mock2を修正前のコードでは正しく動作しないものに変更
