### PR TITLE
再現開始1フレーム目にreadyがあった場合に例外が発生するので修正

### DIFF
--- a/gipo/src/jp/sipo/gipo/reproduce/Reproduce.hx
+++ b/gipo/src/jp/sipo/gipo/reproduce/Reproduce.hx
@@ -231,6 +231,9 @@ class Reproduce<TUpdateKind> extends StateSwitcherGearHolderLowLevelImpl
 		startRecord();
 		// 再生を開始
 		stateSwitcherGear.changeState(new ReproduceReplay(log, executeEvent, replayEnd));
+		
+		// 開始0フレーム目にreadyの記録があった場合に進行を止める
+		canProgress = replayer.checkCanProgress();
 	}
 	/* イベントを実際に実行する処理 */
 	private function executeEvent(part:LogPart<TUpdateKind>):Void


### PR DESCRIPTION
再現開始1フレーム目にreadyがあった場合、checkCanProgressがtrueのままupdateに突入するので、"解消されていないLogPartが残っています。" の例外が発生していた。
