### PR TITLE
ビルドマクロから Context.getType を削除

### DIFF
--- a/gipo/src/jp/sipo/gipo/core/AutoAbsorb.hx
+++ b/gipo/src/jp/sipo/gipo/core/AutoAbsorb.hx
@@ -7,13 +7,23 @@ import haxe.macro.Expr.Constant;
 import haxe.macro.Expr.ExprDef;
 import haxe.macro.Expr.Field;
 import haxe.macro.Expr.FieldType;
+import haxe.macro.Expr.Metadata;
+import haxe.macro.Expr.MetadataEntry;
+import haxe.macro.Expr.Position;
+import haxe.macro.Type.ClassField;
+import haxe.macro.Type.FieldKind;
+import haxe.macro.ExprTools;
 
 using haxe.macro.TypeTools;
+using Lambda;
 
 private typedef MacroType = haxe.macro.Type;
+
 #end
 
-@:autoBuild(jp.sipo.gipo.core._AutoAbsorb.Impl.build())
+#if !macro
+@:build(jp.sipo.gipo.core._AutoAbsorb.Impl.build())
+#end
 interface AutoAbsorb { }
 
 class AutoAbsorbTag {
@@ -24,67 +34,222 @@ class AutoAbsorbTag {
 	public static inline var ABSORB_WITH_KEY_TAG_HOOK:String = ":" + ABSORB_WITH_KEY_TAG;
 }
 
+
 private class Impl {
 	
 	macro private static function build():Array<Field> {
-		var fields = Context.getBuildFields();
+		#if debug_auto_absorb
+		var begin = Sys.cpuTime();
+		#end
 		
-		// すべてのフィールドを走査して
-		for (field in fields) {
-			switch (field) {
-				// 型指定のないメンバ変数
-				case { kind: FieldType.FVar(null, _) } :
-					Context.warning("#5", field.pos);
-				// kind が 'FieldType.FVar' のフィールドに関して
-				case { kind: FieldType.FVar(ComplexType.TPath({ name: tpath_name }), _), meta: field_meta } : 
-					// メンバ変数のメタデータすべてを走査して
-					for (meta in field_meta) {
-						switch (meta.name) {
-							// 対象のメタデータが ABSORB_WITH_KEY_TAG_HOOK('@:absorbWithKey') ならば
-							case AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK :
-								// メタデータのパラメータ全てについて
-								switch (meta.params) {
-									case
-										// パラメータが (foo.bar.baz.Hoge.Fuga) のとき
-										[ { expr: ExprDef.EField({ expr: ExprDef.EField(_, key_enum) }, key_enum_value)} ]
-										// パラメータが (Hoge.Fuga) のとき
-									|	[ { expr: ExprDef.EField({ expr: ExprDef.EConst(Constant.CIdent(key_enum)) }, key_enum_value)} ]
-										if (Context.getType(key_enum).match(MacroType.TEnum)) :
-										// メタデータの名前を '@absorbWithKey' に書き換え
-										meta.name = AutoAbsorbTag.ABSORB_WITH_KEY_TAG;
-										meta.params = [
-											// キーの列挙（Enum)の完全修飾名
-											{ expr : ExprDef.EConst(Constant.CString(Context.getType(key_enum).toString())), pos: Context.currentPos() },
-											// キー（EnumValue）の完全修飾名
-											{ expr : ExprDef.EConst(Constant.CString(key_enum_value)), pos: Context.currentPos() }
-										];
-									// パラメータに値が渡されていない
-									case params if (params.length == 0) :
-										Context.error("#1 : メタデータ '@:absorbWithKey' には、1つのパラメータが必要です。", meta.pos);
-									case params if (params.length >= 2) :
-										Context.error("#2 : メタデータ '@:absorbWithKey' に対して複数のキーが指定されました。", meta.pos);
-									case _ :
-										Context.error("#3 : メタデータのパラメータが対応していない形式です。", meta.pos);
-								}
-							// 対象のメタデータが ABSORB_TAG_HOOK('@:absorb') ならば
-							case AutoAbsorbTag.ABSORB_TAG_HOOK :
-								switch (meta.params) {
-									case [] :
-										meta.name = AutoAbsorbTag.ABSORB_TAG;
-										meta.params = [
-											{ expr: ExprDef.EConst(Constant.CString(Context.getType(tpath_name).toString())), pos: Context.currentPos() }
-										];
-									case _ :
-										Context.error("#4 : メタデータ '@:absorb' にパラメータが指定されました。", meta.pos);
-								}
-						}
-					}
-				case _ :
+		Context.onGenerate(onGenerate);
+		
+		#if debug_auto_absorb
+		var end = Sys.cpuTime();
+		log((end - begin) + 's', Context.currentPos());
+		#end
+		
+		return Context.getBuildFields();
+	}
+	
+	#if macro
+	
+	private static function log(message:Dynamic, pos:Position):Void {
+		#if debug_auto_absorb
+		Context.warning('[AutoAbsorb]' + ' ' + message, pos);
+		#end
+	}
+	
+	
+	private static function onGenerate(types:Array<MacroType>):Void {
+		// すべての型について
+		for (type in types) {
+			switch (type) {
+				case MacroType.TInst(_.get() => classType, _) : 
 					
+					var fields:Array<ClassField> = classType.fields.get();
+					
+					for (field in fields) {
+						
+						if (field.meta.has(AutoAbsorbTag.ABSORB_TAG_HOOK) &&
+						    field.meta.has(AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK))
+						{
+							// '@:absorb' と '@:absorbWithKey' は同時に指定できない
+							Context.fatalError('#0 : 1つのフィールドに対して @:absorb と @:absorbWithKey の両方を指定することはできません', field.pos);
+						}
+						
+						// 以下は '@:absorb' か '@:absorbWithKey' またはどちらでもない
+						
+						// フィールドに関連付けられたすべてのメタデータ
+						var entries:Array<MetadataEntry> = field.meta.get();
+						var pos:Position = field.pos;
+						
+						if (field.meta.has(AutoAbsorbTag.ABSORB_TAG_HOOK)) {
+							// フィールド（変数定義かメソッド定義は問わず）に '@:absorb' の指定がある
+							// この時点で '@:absorbWithKey' は存在しないことが確定
+							
+							if (!isUniqueEntry(entries, AutoAbsorbTag.ABSORB_TAG_HOOK)) {
+								// '@:absorb' の指定が2つ以上見つかった
+								// 2つ以上存在しても本来は問題ないのだが 指定したところで利点等はないため止める
+								Context.fatalError('#1 : 1つの変数に対して2つ以上の @:absorb 指定がされています', pos);
+							}
+							
+							// '@:absorb' の指定はただ1つ（メタデータのエントリは2つ以上存在するかもしれない）
+							analyzeAbsorbField(field, entries);
+						}
+						
+						if (field.meta.has(AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK)) {
+							// フィールド（変数定義かメソッド定義は問わず）に '@:absorbWithKey' の指定がある
+							// この時点で '@:absorb' は存在しないことが確定
+							
+							if (!isUniqueEntry(entries, AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK)) {
+								// '@:absorbWithKey' の指定が2つ以上見つかった
+								Context.fatalError('#2 : 1つの変数に対して複数のキーが指定されています', pos);
+							}
+							
+							// '@:absorbWithKey' の指定はただ1つ（メタデータのエントリは2つ以上存在するかもしれない）
+							analyzeAbsorbWithKeyField(field, entries);
+						}
+						
+					}
+					
+				case _ : 
 			}
 		}
 		
-		return fields;
 	}
+	
+	/**
+	 * 指定した名前のエントリがメタデータ内に1つだけ存在するか
+	 * @param entries
+	 * @param name メタデータエントリの名前
+	 * @return ただ1つ存在するときに真
+	 */
+	private static function isUniqueEntry(entries:Metadata, name:String):Bool {
+		// メタデータから指定の名前のエントリを数える
+		var count:Int = entries.count(function (entry) { return entry.name == name; } );
+		// エントリがただ1つだけ存在（唯一のエントリ）のときに真
+		return count == 1;
+	}
+	
+	/**
+	 * 指定した名前のエントリを検索
+	 * @param entries
+	 * @param name メタデータエントリの名前
+	 * @return 指定したエントリが存在するときそのエントリ
+	 */
+	private static function findMetadata(entries:Metadata, name:String):MetadataEntry {
+		return entries.find(function (entry) { return entry.name == name; } );
+	}
+	
+	/**
+	 * '@:absorb' メタデータが付いたフィールドとして解析
+	 * @param field
+	 * @param entries
+	 */
+	private static function analyzeAbsorbField(field:ClassField, entries:Array<MetadataEntry>):Void {
+		// フィールドの位置（エラー出力用）
+		var pos:Position = field.pos;
+		
+		// フィールドに関して
+		switch (field) {
+			// 関数定義のとき
+			case { kind : FieldKind.FMethod(_) } :
+				Context.fatalError('#3 : メソッド定義に @:absorb は使用できません', pos);
+			// 代入禁止(_, never) と定義されている変数のとき
+			case { kind : FieldKind.FVar(_, AccNever) } :
+				Context.fatalError('#4 : 代入できない変数(never)への @:absorb です', pos);
+			// 適切な形式
+			case { kind : FieldKind.FVar(_, _), type : type = MacroType.TInst(_, _) } :
+				// 変数の型（完全修飾名）
+				var tpath:String = TypeTools.toString(type);
+				
+				log('@:absorb : ' + field.name + ' / ' + tpath, pos);
+				
+				// メタデータの名前を '@absorb' に書き換え
+				
+				// '@:absorb' を削除
+				field.meta.remove(AutoAbsorbTag.ABSORB_TAG_HOOK);
+				// フィールドに '@absorb(tpath)' を追加
+				field.meta.add(AutoAbsorbTag.ABSORB_TAG, [
+					// 変数の型（完全修飾名）をパラメータとして持つ
+					{ expr : ExprDef.EConst(Constant.CString(tpath)), pos: pos }
+				], pos);
+			// 対応していない形式（型定義が TInst以外のもの）
+			case _ : 
+				Context.fatalError('#5 : サポートしていない型に対する @:absorb です', pos);
+		}
+	}
+	
+	/**
+	 * '@:absorbWithKey' メタデータが付いたフィールドとして解析
+	 * @param field
+	 * @param entries
+	 */
+	private static function analyzeAbsorbWithKeyField(field:ClassField, entries:Array<MetadataEntry>):Void {
+		// メタデータのうち '@:absorbWithKey' のエントリ
+		var entry:MetadataEntry = findMetadata(entries, AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK);
+		
+		if (entry.params.length >= 2) {
+			// 1つの定義に複数のキーが指定された
+			Context.fatalError('#6 : @:absorbWithKey に対して複数のキーが指定されています', entry.pos);
+		}
+		
+		if (entry.params.length == 0) {
+			// キーの指定が存在しない
+			Context.fatalError('#7 : @:absorbWithKey には 1つのキーが必要です', entry.pos);
+		}
+		
+		// キーは定義に対して1つだけ存在
+		
+		// メタデータ '@:absorbWithKey(foobar.baz.Hoge.Fuga)' が定義されているとき
+		var tpath:String = null; // 'foobar.baz.Hoge'
+		var value:String = null; // 'Fuga'
+		
+		{
+			var strs = ExprTools.toString(entry.params[0]).split('.');
+			
+			tpath = strs.slice( 0, -1).join('.');
+			value = strs.slice(-1    ).join('.');
+		}
+		
+		try {
+			// 指定した型Enum を取得
+			// 型が存在しな場合はエラーが送出され制御がcatchに移る
+			var key:MacroType = Context.getType(tpath);
+			
+			// 型Enum は存在する
+			switch (key) {
+				case MacroType.TEnum(_.get() => enumType, _) : 
+					if (enumType.names.indexOf(value) == -1) {
+						// 型'tpath' には値 'value'が定義されていない
+						Context.fatalError('#8 : 値 ${value} は ${tpath} に定義されていません', entry.pos);
+					}
+					
+					log('@:absorbWithKey : ' + field.name + ' / ' + tpath + '.' + value, field.pos);
+					
+					// メタデータの名前を '@absorbWithKey' に書き換え
+					
+					// '@:absorbWithKey' を削除
+					field.meta.remove(AutoAbsorbTag.ABSORB_WITH_KEY_TAG_HOOK);
+					// フィールドに '@absorbWithKey(tpath, value)' を追加
+					field.meta.add(AutoAbsorbTag.ABSORB_WITH_KEY_TAG, [
+						// キーの列挙(Enum)の完全修飾名
+						{ expr : ExprDef.EConst(Constant.CString(tpath)), pos : Context.currentPos() },
+						// キー(EnumValue)の完全修飾名
+						{ expr : ExprDef.EConst(Constant.CString(value)), pos : Context.currentPos() },
+					], Context.currentPos());
+					
+				case _ : 
+					Context.fatalError('#9 : 対応していない形式のキーが指定されています（キーは EnumValueのみ対応しています）', entry.pos);
+			}
+			
+		} catch (error:String) {
+			Context.fatalError(error + ' (try using absolute path)', entry.pos);
+		}
+		
+	}
+	
+	#end
 	
 }

--- a/gipo/src/jp/sipo/gipo/core/AutoAbsorb.hx
+++ b/gipo/src/jp/sipo/gipo/core/AutoAbsorb.hx
@@ -38,17 +38,7 @@ class AutoAbsorbTag {
 private class Impl {
 	
 	macro private static function build():Array<Field> {
-		#if debug_auto_absorb
-		var begin = Sys.cpuTime();
-		#end
-		
 		Context.onGenerate(onGenerate);
-		
-		#if debug_auto_absorb
-		var end = Sys.cpuTime();
-		log((end - begin) + 's', Context.currentPos());
-		#end
-		
 		return Context.getBuildFields();
 	}
 	
@@ -59,7 +49,6 @@ private class Impl {
 		Context.warning('[AutoAbsorb]' + ' ' + message, pos);
 		#end
 	}
-	
 	
 	private static function onGenerate(types:Array<MacroType>):Void {
 		// すべての型について

--- a/gipo/test/DiffuseDataKey.hx
+++ b/gipo/test/DiffuseDataKey.hx
@@ -1,0 +1,7 @@
+package;
+
+enum DiffuseDataKey
+{
+	Key1;
+	Key2;
+}

--- a/gipo/test/DiffuseDataKey.hx
+++ b/gipo/test/DiffuseDataKey.hx
@@ -1,7 +1,0 @@
-package;
-
-enum DiffuseDataKey
-{
-	Key1;
-	Key2;
-}

--- a/gipo/test/DiffuseTest.hx
+++ b/gipo/test/DiffuseTest.hx
@@ -386,7 +386,7 @@ class DiffuseWithKeyTop extends GearHolderImpl
 
 class DiffuseWithKeyNode extends DiffuseWithKeyTop
 {
-	@:absorbWithKey(DiffuseDataKey.Key1)
+	@:absorbWithKey(DiffuseTest.DiffuseDataKey.Key1)
 	public var autoData:DiffuseData;
 
 	public function new(info:DiffuseTreeInfo)
@@ -424,4 +424,10 @@ class DiffuseData
 class DiffuseDataSub extends DiffuseData
 {
 	public function new() { super(); }
+}
+
+enum DiffuseDataKey
+{
+	Key1;
+	Key2;
 }

--- a/gipo/test/DiffuseTest.hx
+++ b/gipo/test/DiffuseTest.hx
@@ -425,9 +425,3 @@ class DiffuseDataSub extends DiffuseData
 {
 	public function new() { super(); }
 }
-
-enum DiffuseDataKey
-{
-	Key1;
-	Key2;
-}

--- a/template/src/jp/sipo/gipo_framework_example/context/Hook.hx
+++ b/template/src/jp/sipo/gipo_framework_example/context/Hook.hx
@@ -55,7 +55,7 @@ class Hook extends GearHolderImpl implements HookForView implements HookForLogic
 {
 	@:absorb
 	private var logic:LogicForHook;
-	@:absorbWithKey(TopDiffuseKey.ReproduceKey)
+	@:absorbWithKey(jp.sipo.gipo_framework_example.context.Top.TopDiffuseKey.ReproduceKey)
 	private var reproduce:Reproduce<UpdateKind>;
 	
 	/** コンストラクタ */

--- a/template/src/jp/sipo/gipo_framework_example/operation/OperationLogic.hx
+++ b/template/src/jp/sipo/gipo_framework_example/operation/OperationLogic.hx
@@ -23,7 +23,7 @@ class OperationLogic extends GearHolderImpl
 {
 	@:absorb
 	private var operationView:OperationView;
-	@:absorbWithKey(TopDiffuseKey.ReproduceKey)
+	@:absorbWithKey(jp.sipo.gipo_framework_example.context.Top.TopDiffuseKey.ReproduceKey)
 	private var reproduce:Reproduce<UpdateKind>;
 	
 	/* 最後に読み込んだログ */

--- a/template/src/jp/sipo/gipo_framework_example/pilotView/PilotViewScene.hx
+++ b/template/src/jp/sipo/gipo_framework_example/pilotView/PilotViewScene.hx
@@ -15,7 +15,7 @@ import jp.sipo.gipo.core.handler.AddBehaviorPreset;
 import flash.display.Sprite;
 class PilotViewScene extends StateGearHolderImpl implements ViewSceneOrder
 {
-	@:absorbWithKey(PilotViewDiffuseKey.GameLayer)
+	@:absorbWithKey(jp.sipo.gipo_framework_example.pilotView.PilotView.PilotViewDiffuseKey.GameLayer)
 	private var layer:Sprite;
 	@:absorb
 	/* シーン用のinputを生成する */


### PR DESCRIPTION
Haxe 3.2 以上のバージョンで特定の条件が揃うとビルドマクロ中の
`Context.getType` が正しく動作しないという不具合があり、その件に対応するパッチです。

このパッチは、機能 `@:absorbWithKey` に関して後方互換性がありません。
1. @:absorbWithKey に指定するキーは完全修飾名で指定する必要があります。
   例えば `@:absorbWithKey(foobar.Baz.Hoge)` などと指定する必要があります。
   モジュール内に import 宣言が存在しても完全修飾名による指定が必要です（キーの型解決に失敗すると `try using absolute path` とエラーが出力されます）
2. ~~@:absorbWithKey に指定するキーの型は、モジュールの完全修飾名と一致する必要があります。
   （キーとなる enumでファイルを作る必要があるということです。 4c316dbc2d2fdca60774a5a6ec984cbe0b50a400 の変更を参照してください）~~

@:absorb, @:absorbWithKey が正しく使用されていない場合適切なエラーを出力するようになっています。
#3 に関しても 定義したフィールドの箇所をエラーとして示すようになっています。
