### PR TITLE
diffuseWithKeyで別の型のEnumをkeyにしてdiffuseしても正しく動作するように

### DIFF
--- a/gipo/test/DiffuseTest.hx
+++ b/gipo/test/DiffuseTest.hx
@@ -376,6 +376,7 @@ class DiffuseWithKeyTop extends GearHolderImpl
 	{
 		if(info.diffuseData != null) {
 			tool.diffuseWithKey(info.diffuseData, DiffuseDataKey.Key1);
+			tool.diffuseWithKey(info.diffuseData, DiffuseDataKey2.Key1);
 		}
 
 		for(child in info.children) {
@@ -427,6 +428,12 @@ class DiffuseDataSub extends DiffuseData
 }
 
 enum DiffuseDataKey
+{
+	Key1;
+	Key2;
+}
+
+enum DiffuseDataKey2
 {
 	Key1;
 	Key2;


### PR DESCRIPTION
タイトルの通り。別の型のEnumを同じMapに入れると正しく動作しないため、型ごとにMapを分けるように
